### PR TITLE
set up index.html and index.jsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
         "react"
     ],
     "rules": {
-        "no-console": "off"
+        "no-console": "off",
+        "import/extensions": "off"
     }
 }

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -1,1 +1,16 @@
-<!-- main html file, I (cesar) will fill this in later -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="./css/product_detail_styles.css"></link>
+  <title>PLUMBERSFEC</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script src="./bundle.js"></script>
+</body>
+
+</html>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,2 +1,15 @@
-//App.jsx to unify all the components later on, do not delete until otherwise..
-//Only make new .jsx files in your own component folders until otherwise (this is to avoid merge conflicts or complications)
+/* eslint-disable padded-blocks */
+/* eslint-disable no-unused-vars */
+import React from 'react';
+import ProductDetail from './product_detail/Product_detail_main.jsx';
+
+function App(props) {
+
+  return (
+    <div>
+      <ProductDetail />
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,12 +1,6 @@
-//index.jsx to render App.jsx later on, do not delete until otherwise..
-//Only make new .jsx files in your own component folders until otherwise (this is to avoid merge conflicts or complications)
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import App from './components/App.jsx';
 
-
-
-//import styles from '../dist/style.css'
-
-//put callback here
-
-// ReactDOM.render(document.getElementById('app'));
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
In .eslintrc.json: adding "import/extensions": "off" to ignore import file extensions error from eslint
In client/dist/index.html: set up index.html, add your own css file like line 7(a new line same code, just change filename)
In client/src/components/App.jsx, just a simple set up, feel free to import your part. we will modify it more in the future
In client/src/index.jsx: set up react in a react 18 way. Setup in the old way, chrome will whine ReactDOM is outdated
 